### PR TITLE
Add KEDA autoscaling load test scripts

### DIFF
--- a/charts/energy-pipeline/templates/keda-autoscaler.yaml
+++ b/charts/energy-pipeline/templates/keda-autoscaler.yaml
@@ -13,7 +13,7 @@ spec:
   triggers:
     - type: redis-streams
       metadata:
-        address: {{ include "energy-pipeline.redisHost" . }}:6379
+        address: {{ include "energy-pipeline.redisHost" . }}.{{ .Release.Namespace }}.svc.cluster.local:6379
         stream: {{ .Values.config.redisStream | quote }}
         consumerGroup: {{ .Values.config.consumerGroup | quote }}
         pendingEntriesCount: {{ .Values.keda.threshold | quote }}

--- a/scripts/test-keda-autoscaling.ps1
+++ b/scripts/test-keda-autoscaling.ps1
@@ -22,7 +22,9 @@
     Number of parallel batches to send at once (default: 10)
 
 .PARAMETER IngressUrl
-    External URL if using ingress/tunnel. If empty, uses port-forward.
+    External URL if using ingress/tunnel (e.g. https://energy.frishchin.com).
+    When set, requests go through the frontend proxy (/api/readings).
+    When empty, port-forwards directly to the ingestion API (/readings).
 
 .EXAMPLE
     .\test-keda-autoscaling.ps1
@@ -81,11 +83,15 @@ kubectl get pods -n $Namespace -l "app.kubernetes.io/component=processing-servic
 Write-Info "ScaledObject status:"
 kubectl get scaledobject -n $Namespace
 
-# Get stream info via processing service metrics endpoint
-Write-Info "Checking Redis stream metrics..."
+# Check ScaledObject health
+Write-Info "ScaledObject events (last 5):"
+kubectl get events -n $Namespace --field-selector involvedObject.kind=ScaledObject --sort-by='.lastTimestamp' 2>&1 | Select-Object -Last 6
 
-# --- Setup Port Forward (if no external URL) ---
+# --- Setup Port Forward or External URL ---
 $portForwardJob = $null
+$ReadingsEndpoint = ""
+$HealthEndpoint = ""
+
 if ([string]::IsNullOrWhiteSpace($IngressUrl)) {
     Write-Header "Setting Up Port Forward"
 
@@ -96,7 +102,7 @@ if ([string]::IsNullOrWhiteSpace($IngressUrl)) {
         exit 1
     }
 
-    # Port forward in background
+    # Port forward in background (directly to ingestion-api service)
     $portForwardJob = Start-Job -ScriptBlock {
         param($ns, $pod)
         kubectl port-forward -n $ns $pod 8080:8000
@@ -104,19 +110,58 @@ if ([string]::IsNullOrWhiteSpace($IngressUrl)) {
 
     Start-Sleep -Seconds 3
     $BaseUrl = "http://localhost:8080"
-    Write-Ok "Port forward active: $BaseUrl -> $ingestPod"
+    # Direct to ingestion API: paths are /readings and /health
+    $ReadingsEndpoint = "$BaseUrl/readings"
+    $HealthEndpoint = "$BaseUrl/health"
+    Write-Ok "Port forward active: $BaseUrl -> $ingestPod (direct to ingestion API)"
 } else {
     $BaseUrl = $IngressUrl.TrimEnd("/")
-    Write-Ok "Using external URL: $BaseUrl"
+    # Through frontend nginx proxy: /api/readings -> /readings
+    $ReadingsEndpoint = "$BaseUrl/api/readings"
+    $HealthEndpoint = "$BaseUrl"  # Frontend serves HTML at /
+    Write-Ok "Using external URL: $BaseUrl (through frontend proxy)"
+    Write-Info "Readings endpoint: $ReadingsEndpoint"
 }
 
 # --- Verify API is reachable ---
 Write-Header "Verifying API"
 try {
-    $health = Invoke-RestMethod -Uri "$BaseUrl/health" -Method Get -TimeoutSec 10
-    Write-Ok "Ingestion API healthy: $($health.status)"
+    if ([string]::IsNullOrWhiteSpace($IngressUrl)) {
+        # Direct port-forward: check /health
+        $health = Invoke-RestMethod -Uri $HealthEndpoint -Method Get -TimeoutSec 10
+        Write-Ok "Ingestion API healthy: $($health.status)"
+    } else {
+        # External URL: test with a simple GET to the frontend
+        $response = Invoke-WebRequest -Uri $HealthEndpoint -Method Get -TimeoutSec 10 -UseBasicParsing
+        if ($response.StatusCode -eq 200) {
+            Write-Ok "Frontend reachable at $BaseUrl"
+        }
+        # Also test the /api/readings endpoint with a test POST
+        Write-Info "Testing readings endpoint with a probe..."
+        $probeBody = @{
+            site_id       = "probe-test"
+            device_id     = "probe-1"
+            power_reading = 1.0
+            timestamp     = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+        } | ConvertTo-Json
+
+        try {
+            $probeResult = Invoke-RestMethod -Uri $ReadingsEndpoint `
+                -Method Post `
+                -ContentType "application/json" `
+                -Body $probeBody `
+                -TimeoutSec 10
+            Write-Ok "Readings endpoint working: stream_id=$($probeResult.stream_id)"
+        } catch {
+            Write-Err "Readings endpoint failed: $($_.Exception.Message)"
+            Write-Err "URL: $ReadingsEndpoint"
+            Write-Info "Make sure the Cloudflare tunnel is routing to the frontend service."
+            if ($portForwardJob) { Stop-Job $portForwardJob; Remove-Job $portForwardJob }
+            exit 1
+        }
+    }
 } catch {
-    Write-Err "Cannot reach ingestion API at $BaseUrl/health"
+    Write-Err "Cannot reach API at $HealthEndpoint"
     Write-Err $_.Exception.Message
     if ($portForwardJob) { Stop-Job $portForwardJob; Remove-Job $portForwardJob }
     exit 1
@@ -125,10 +170,12 @@ try {
 # --- Flood the Stream ---
 Write-Header "Flooding Stream with $TotalMessages Messages"
 Write-Info "This will build a backlog that triggers KEDA to scale up processing pods..."
+Write-Info "Endpoint: $ReadingsEndpoint"
 Write-Host ""
 
 $sent = 0
 $errors = 0
+$lastError = ""
 $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
 # Send in batches
@@ -150,9 +197,9 @@ for ($batch = 0; $batch -lt $totalBatches; $batch++) {
         } | ConvertTo-Json
 
         $jobs += Start-Job -ScriptBlock {
-            param($url, $jsonBody)
+            param($endpoint, $jsonBody)
             try {
-                $response = Invoke-RestMethod -Uri "$url/readings" `
+                $response = Invoke-RestMethod -Uri $endpoint `
                     -Method Post `
                     -ContentType "application/json" `
                     -Body $jsonBody `
@@ -161,7 +208,7 @@ for ($batch = 0; $batch -lt $totalBatches; $batch++) {
             } catch {
                 return @{ success = $false; error = $_.Exception.Message }
             }
-        } -ArgumentList $BaseUrl, $body
+        } -ArgumentList $ReadingsEndpoint, $body
     }
 
     # Wait for batch to complete
@@ -169,7 +216,12 @@ for ($batch = 0; $batch -lt $totalBatches; $batch++) {
     $jobs | Remove-Job
 
     foreach ($r in $results) {
-        if ($r.success) { $sent++ } else { $errors++ }
+        if ($r.success) {
+            $sent++
+        } else {
+            $errors++
+            $lastError = $r.error
+        }
     }
 
     $pct = [Math]::Round(($sent + $errors) / $TotalMessages * 100, 0)
@@ -179,7 +231,19 @@ for ($batch = 0; $batch -lt $totalBatches; $batch++) {
 $stopwatch.Stop()
 Write-Host ""
 Write-Ok "Flood complete: $sent sent, $errors errors in $([Math]::Round($stopwatch.Elapsed.TotalSeconds, 1))s"
-Write-Host "  Rate: $([Math]::Round($sent / $stopwatch.Elapsed.TotalSeconds, 1)) msg/s"
+if ($sent -gt 0) {
+    Write-Host "  Rate: $([Math]::Round($sent / $stopwatch.Elapsed.TotalSeconds, 1)) msg/s"
+}
+if ($errors -gt 0 -and $lastError) {
+    Write-Err "Last error: $lastError"
+}
+
+if ($sent -eq 0) {
+    Write-Err "No messages were sent successfully. Cannot test scaling."
+    Write-Info "Check that the ingestion API is reachable and Redis is running."
+    if ($portForwardJob) { Stop-Job $portForwardJob; Remove-Job $portForwardJob }
+    exit 1
+}
 
 # --- Monitor Scaling ---
 Write-Header "Monitoring KEDA Scaling (watching for ~2 minutes)"
@@ -198,35 +262,45 @@ while ($elapsed -lt $maxWait) {
         -l "app.kubernetes.io/component=processing-service" `
         -o jsonpath="{.items[0].status.replicas}" 2>&1
 
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($replicas)) { $replicas = "?" }
+
     $readyReplicas = kubectl get deployment -n $Namespace `
         -l "app.kubernetes.io/component=processing-service" `
         -o jsonpath="{.items[0].status.readyReplicas}" 2>&1
 
-    if ([string]::IsNullOrWhiteSpace($readyReplicas)) { $readyReplicas = "0" }
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($readyReplicas)) { $readyReplicas = "0" }
 
-    # Get pending entries from ScaledObject
-    $pendingInfo = kubectl get scaledobject -n $Namespace -o jsonpath="{.items[0].status.conditions}" 2>&1
-
-    # Get HPA info (KEDA creates an HPA)
-    $hpaDesired = kubectl get hpa -n $Namespace -o jsonpath="{.items[0].status.desiredReplicas}" 2>&1
-    if ([string]::IsNullOrWhiteSpace($hpaDesired)) { $hpaDesired = "?" }
+    # Get HPA info (KEDA creates an HPA) — may not exist yet
+    $hpaDesired = "n/a"
+    try {
+        $hpaResult = kubectl get hpa -n $Namespace -o jsonpath="{.items[0].status.desiredReplicas}" 2>&1
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($hpaResult)) {
+            $hpaDesired = $hpaResult
+        }
+    } catch {
+        $hpaDesired = "n/a"
+    }
 
     $timestamp = (Get-Date).ToString("HH:mm:ss")
 
-    if ($replicas -ne $prevReplicas) {
+    if ($replicas -ne "?" -and $replicas -ne $prevReplicas) {
         if ($prevReplicas -ne -1) {
             Write-Host ""
-            if ([int]$replicas -gt [int]$prevReplicas) {
-                Write-Host "  >>> SCALED UP: $prevReplicas -> $replicas replicas <<<" -ForegroundColor Green
-                $scaledUp = $true
-            } else {
-                Write-Host "  >>> SCALED DOWN: $prevReplicas -> $replicas replicas <<<" -ForegroundColor Magenta
+            try {
+                if ([int]$replicas -gt [int]$prevReplicas) {
+                    Write-Host "  >>> SCALED UP: $prevReplicas -> $replicas replicas <<<" -ForegroundColor Green
+                    $scaledUp = $true
+                } elseif ([int]$replicas -lt [int]$prevReplicas) {
+                    Write-Host "  >>> SCALED DOWN: $prevReplicas -> $replicas replicas <<<" -ForegroundColor Magenta
+                }
+            } catch {
+                # Ignore parse errors
             }
         }
         $prevReplicas = $replicas
     }
 
-    Write-Host "`r  [$timestamp] Replicas: $readyReplicas/$replicas ready | HPA desired: $hpaDesired | Elapsed: ${elapsed}s" -NoNewline
+    Write-Host "`r  [$timestamp] Replicas: $readyReplicas/$replicas ready | HPA desired: $hpaDesired | Elapsed: ${elapsed}s   " -NoNewline
 
     Start-Sleep -Seconds 5
     $elapsed += 5
@@ -244,17 +318,32 @@ Write-Info "ScaledObject:"
 kubectl get scaledobject -n $Namespace
 
 Write-Info "HPA (created by KEDA):"
-kubectl get hpa -n $Namespace
+$hpaOutput = kubectl get hpa -n $Namespace 2>&1
+if ($LASTEXITCODE -eq 0) {
+    Write-Host $hpaOutput
+} else {
+    Write-Host "  No HPA found (KEDA may not have created one yet)"
+}
+
+Write-Info "ScaledObject details:"
+kubectl describe scaledobject -n $Namespace 2>&1 | Select-String -Pattern "Type|Status|Message|Reason|Ready|Active" | Select-Object -First 10
 
 if ($scaledUp) {
+    Write-Host ""
     Write-Ok "SUCCESS: KEDA autoscaling worked! Pods scaled up in response to stream backlog."
 } else {
+    Write-Host ""
     Write-Info "Pods didn't scale during the monitoring window."
     Write-Info "This could mean:"
-    Write-Info "  - Processing was fast enough to keep up (no backlog built)"
+    Write-Info "  - Processing was fast enough to keep up (no backlog > threshold of 5)"
     Write-Info "  - KEDA polling interval hasn't triggered yet (try waiting longer)"
-    Write-Info "  - Try increasing -TotalMessages (e.g. 500) or check ScaledObject events:"
-    Write-Host "    kubectl describe scaledobject -n $Namespace"
+    Write-Info "  - ScaledObject is not READY (check events below)"
+    Write-Info "  - Try increasing -TotalMessages (e.g. 500)"
+    Write-Host ""
+    Write-Info "Debug commands:"
+    Write-Host "  kubectl describe scaledobject -n $Namespace"
+    Write-Host "  kubectl get events -n $Namespace --field-selector involvedObject.kind=ScaledObject"
+    Write-Host "  kubectl logs -n keda -l app=keda-operator --tail=50"
 }
 
 # --- Cleanup ---
@@ -274,3 +363,4 @@ Write-Info "To keep monitoring manually:"
 Write-Host "  kubectl get pods -n $Namespace -l app.kubernetes.io/component=processing-service -w"
 Write-Host "  kubectl get hpa -n $Namespace -w"
 Write-Host "  kubectl describe scaledobject -n $Namespace"
+Write-Host "  kubectl logs -n keda -l app=keda-operator --tail=50"

--- a/scripts/test-keda-autoscaling.ps1
+++ b/scripts/test-keda-autoscaling.ps1
@@ -318,10 +318,14 @@ Write-Info "ScaledObject:"
 kubectl get scaledobject -n $Namespace
 
 Write-Info "HPA (created by KEDA):"
-$hpaOutput = kubectl get hpa -n $Namespace 2>&1
-if ($LASTEXITCODE -eq 0) {
-    Write-Host $hpaOutput
-} else {
+try {
+    $hpaOutput = kubectl get hpa -n $Namespace 2>&1
+    if ($LASTEXITCODE -eq 0 -and $hpaOutput -notmatch "No resources found") {
+        Write-Host $hpaOutput
+    } else {
+        Write-Host "  No HPA found (KEDA may not have created one yet)"
+    }
+} catch {
     Write-Host "  No HPA found (KEDA may not have created one yet)"
 }
 

--- a/scripts/test-keda-autoscaling.ps1
+++ b/scripts/test-keda-autoscaling.ps1
@@ -1,0 +1,276 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Tests KEDA autoscaling by flooding the ingestion API with readings
+    and monitoring the processing service replica count.
+
+.DESCRIPTION
+    This script:
+    1. Checks KEDA is installed and the ScaledObject exists
+    2. Shows current state (replicas, stream pending count)
+    3. Floods the ingestion API with readings to build a backlog
+    4. Monitors pod scaling in real-time
+    5. Waits for scale-down after backlog is cleared
+
+.PARAMETER Namespace
+    Kubernetes namespace where the release is deployed (default: energy-pipeline)
+
+.PARAMETER TotalMessages
+    Number of readings to send (default: 100)
+
+.PARAMETER ConcurrentBatches
+    Number of parallel batches to send at once (default: 10)
+
+.PARAMETER IngressUrl
+    External URL if using ingress/tunnel. If empty, uses port-forward.
+
+.EXAMPLE
+    .\test-keda-autoscaling.ps1
+    .\test-keda-autoscaling.ps1 -Namespace default -TotalMessages 200
+    .\test-keda-autoscaling.ps1 -IngressUrl "https://energy.frishchin.com"
+#>
+
+param(
+    [string]$Namespace = "energy-pipeline",
+    [int]$TotalMessages = 100,
+    [int]$ConcurrentBatches = 10,
+    [string]$IngressUrl = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Colors & helpers ---
+function Write-Header($msg) { Write-Host "`n=== $msg ===" -ForegroundColor Cyan }
+function Write-Ok($msg)     { Write-Host "[OK] $msg" -ForegroundColor Green }
+function Write-Info($msg)   { Write-Host "[INFO] $msg" -ForegroundColor Yellow }
+function Write-Err($msg)    { Write-Host "[ERROR] $msg" -ForegroundColor Red }
+
+# --- Preflight Checks ---
+Write-Header "KEDA Autoscaling Test"
+Write-Host "Namespace:       $Namespace"
+Write-Host "Total messages:  $TotalMessages"
+Write-Host "Concurrency:     $ConcurrentBatches"
+Write-Host ""
+
+# Check KEDA CRDs exist
+Write-Header "Preflight Checks"
+
+$kedaCRD = kubectl get crd scaledobjects.keda.sh --no-headers 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "KEDA CRDs not found. Install KEDA first:"
+    Write-Host "  helm repo add kedacore https://kedacore.github.io/charts"
+    Write-Host "  helm install keda kedacore/keda --namespace keda --create-namespace"
+    exit 1
+}
+Write-Ok "KEDA CRDs found"
+
+# Check ScaledObject exists
+$scaledObj = kubectl get scaledobject -n $Namespace --no-headers 2>&1
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($scaledObj)) {
+    Write-Err "No ScaledObject found in namespace '$Namespace'. Make sure keda.enabled=true in values.yaml"
+    exit 1
+}
+Write-Ok "ScaledObject found: $($scaledObj.Trim())"
+
+# --- Show Initial State ---
+Write-Header "Initial State"
+
+Write-Info "Processing Service pods:"
+kubectl get pods -n $Namespace -l "app.kubernetes.io/component=processing-service" --no-headers
+
+Write-Info "ScaledObject status:"
+kubectl get scaledobject -n $Namespace
+
+# Get stream info via processing service metrics endpoint
+Write-Info "Checking Redis stream metrics..."
+
+# --- Setup Port Forward (if no external URL) ---
+$portForwardJob = $null
+if ([string]::IsNullOrWhiteSpace($IngressUrl)) {
+    Write-Header "Setting Up Port Forward"
+
+    # Find ingestion-api pod
+    $ingestPod = kubectl get pods -n $Namespace -l "app.kubernetes.io/component=ingestion-api" -o jsonpath="{.items[0].metadata.name}" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Cannot find ingestion-api pod in namespace '$Namespace'"
+        exit 1
+    }
+
+    # Port forward in background
+    $portForwardJob = Start-Job -ScriptBlock {
+        param($ns, $pod)
+        kubectl port-forward -n $ns $pod 8080:8000
+    } -ArgumentList $Namespace, $ingestPod
+
+    Start-Sleep -Seconds 3
+    $BaseUrl = "http://localhost:8080"
+    Write-Ok "Port forward active: $BaseUrl -> $ingestPod"
+} else {
+    $BaseUrl = $IngressUrl.TrimEnd("/")
+    Write-Ok "Using external URL: $BaseUrl"
+}
+
+# --- Verify API is reachable ---
+Write-Header "Verifying API"
+try {
+    $health = Invoke-RestMethod -Uri "$BaseUrl/health" -Method Get -TimeoutSec 10
+    Write-Ok "Ingestion API healthy: $($health.status)"
+} catch {
+    Write-Err "Cannot reach ingestion API at $BaseUrl/health"
+    Write-Err $_.Exception.Message
+    if ($portForwardJob) { Stop-Job $portForwardJob; Remove-Job $portForwardJob }
+    exit 1
+}
+
+# --- Flood the Stream ---
+Write-Header "Flooding Stream with $TotalMessages Messages"
+Write-Info "This will build a backlog that triggers KEDA to scale up processing pods..."
+Write-Host ""
+
+$sent = 0
+$errors = 0
+$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+# Send in batches
+$batchSize = $ConcurrentBatches
+$totalBatches = [Math]::Ceiling($TotalMessages / $batchSize)
+
+for ($batch = 0; $batch -lt $totalBatches; $batch++) {
+    $jobs = @()
+    $remaining = [Math]::Min($batchSize, $TotalMessages - ($batch * $batchSize))
+
+    for ($i = 0; $i -lt $remaining; $i++) {
+        $msgNum = ($batch * $batchSize) + $i + 1
+        $ts = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+        $body = @{
+            site_id       = "load-test-site-$(($msgNum % 5) + 1)"
+            device_id     = "meter-$msgNum"
+            power_reading = [Math]::Round((Get-Random -Minimum 100.0 -Maximum 5000.0), 1)
+            timestamp     = $ts
+        } | ConvertTo-Json
+
+        $jobs += Start-Job -ScriptBlock {
+            param($url, $jsonBody)
+            try {
+                $response = Invoke-RestMethod -Uri "$url/readings" `
+                    -Method Post `
+                    -ContentType "application/json" `
+                    -Body $jsonBody `
+                    -TimeoutSec 30
+                return @{ success = $true; stream_id = $response.stream_id }
+            } catch {
+                return @{ success = $false; error = $_.Exception.Message }
+            }
+        } -ArgumentList $BaseUrl, $body
+    }
+
+    # Wait for batch to complete
+    $results = $jobs | Wait-Job | Receive-Job
+    $jobs | Remove-Job
+
+    foreach ($r in $results) {
+        if ($r.success) { $sent++ } else { $errors++ }
+    }
+
+    $pct = [Math]::Round(($sent + $errors) / $TotalMessages * 100, 0)
+    Write-Host "`r  Sent: $sent / $TotalMessages ($pct%%) | Errors: $errors" -NoNewline
+}
+
+$stopwatch.Stop()
+Write-Host ""
+Write-Ok "Flood complete: $sent sent, $errors errors in $([Math]::Round($stopwatch.Elapsed.TotalSeconds, 1))s"
+Write-Host "  Rate: $([Math]::Round($sent / $stopwatch.Elapsed.TotalSeconds, 1)) msg/s"
+
+# --- Monitor Scaling ---
+Write-Header "Monitoring KEDA Scaling (watching for ~2 minutes)"
+Write-Info "KEDA polls every ~15-30s. Watch for replica count changes..."
+Write-Info "Press Ctrl+C to stop monitoring early."
+Write-Host ""
+
+$maxWait = 120  # seconds
+$elapsed = 0
+$prevReplicas = -1
+$scaledUp = $false
+
+while ($elapsed -lt $maxWait) {
+    # Get current replica count
+    $replicas = kubectl get deployment -n $Namespace `
+        -l "app.kubernetes.io/component=processing-service" `
+        -o jsonpath="{.items[0].status.replicas}" 2>&1
+
+    $readyReplicas = kubectl get deployment -n $Namespace `
+        -l "app.kubernetes.io/component=processing-service" `
+        -o jsonpath="{.items[0].status.readyReplicas}" 2>&1
+
+    if ([string]::IsNullOrWhiteSpace($readyReplicas)) { $readyReplicas = "0" }
+
+    # Get pending entries from ScaledObject
+    $pendingInfo = kubectl get scaledobject -n $Namespace -o jsonpath="{.items[0].status.conditions}" 2>&1
+
+    # Get HPA info (KEDA creates an HPA)
+    $hpaDesired = kubectl get hpa -n $Namespace -o jsonpath="{.items[0].status.desiredReplicas}" 2>&1
+    if ([string]::IsNullOrWhiteSpace($hpaDesired)) { $hpaDesired = "?" }
+
+    $timestamp = (Get-Date).ToString("HH:mm:ss")
+
+    if ($replicas -ne $prevReplicas) {
+        if ($prevReplicas -ne -1) {
+            Write-Host ""
+            if ([int]$replicas -gt [int]$prevReplicas) {
+                Write-Host "  >>> SCALED UP: $prevReplicas -> $replicas replicas <<<" -ForegroundColor Green
+                $scaledUp = $true
+            } else {
+                Write-Host "  >>> SCALED DOWN: $prevReplicas -> $replicas replicas <<<" -ForegroundColor Magenta
+            }
+        }
+        $prevReplicas = $replicas
+    }
+
+    Write-Host "`r  [$timestamp] Replicas: $readyReplicas/$replicas ready | HPA desired: $hpaDesired | Elapsed: ${elapsed}s" -NoNewline
+
+    Start-Sleep -Seconds 5
+    $elapsed += 5
+}
+
+Write-Host ""
+
+# --- Final State ---
+Write-Header "Final State"
+
+Write-Info "Processing Service pods:"
+kubectl get pods -n $Namespace -l "app.kubernetes.io/component=processing-service"
+
+Write-Info "ScaledObject:"
+kubectl get scaledobject -n $Namespace
+
+Write-Info "HPA (created by KEDA):"
+kubectl get hpa -n $Namespace
+
+if ($scaledUp) {
+    Write-Ok "SUCCESS: KEDA autoscaling worked! Pods scaled up in response to stream backlog."
+} else {
+    Write-Info "Pods didn't scale during the monitoring window."
+    Write-Info "This could mean:"
+    Write-Info "  - Processing was fast enough to keep up (no backlog built)"
+    Write-Info "  - KEDA polling interval hasn't triggered yet (try waiting longer)"
+    Write-Info "  - Try increasing -TotalMessages (e.g. 500) or check ScaledObject events:"
+    Write-Host "    kubectl describe scaledobject -n $Namespace"
+}
+
+# --- Cleanup ---
+Write-Header "Cleanup"
+if ($portForwardJob) {
+    Stop-Job $portForwardJob -ErrorAction SilentlyContinue
+    Remove-Job $portForwardJob -ErrorAction SilentlyContinue
+    Write-Ok "Port forward stopped"
+}
+
+Write-Info "Load test data was written to sites: load-test-site-1 through load-test-site-5"
+Write-Info "To clean up test data, you can delete those keys from Redis:"
+Write-Host "  kubectl exec -n $Namespace deploy/energy-pipeline-redis-master -- redis-cli DEL site:load-test-site-1:readings site:load-test-site-2:readings site:load-test-site-3:readings site:load-test-site-4:readings site:load-test-site-5:readings"
+
+Write-Host ""
+Write-Info "To keep monitoring manually:"
+Write-Host "  kubectl get pods -n $Namespace -l app.kubernetes.io/component=processing-service -w"
+Write-Host "  kubectl get hpa -n $Namespace -w"
+Write-Host "  kubectl describe scaledobject -n $Namespace"

--- a/scripts/test-keda-autoscaling.sh
+++ b/scripts/test-keda-autoscaling.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# KEDA Autoscaling Test
+# Floods the ingestion API with readings and monitors processing pod scaling.
+#
+# Usage:
+#   ./scripts/test-keda-autoscaling.sh [NAMESPACE] [TOTAL_MESSAGES] [INGRESS_URL]
+#
+# Examples:
+#   ./scripts/test-keda-autoscaling.sh energy-pipeline 100
+#   ./scripts/test-keda-autoscaling.sh energy-pipeline 200 https://energy.frishchin.com
+
+set -euo pipefail
+
+NAMESPACE="${1:-energy-pipeline}"
+TOTAL_MESSAGES="${2:-100}"
+INGRESS_URL="${3:-}"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+MAGENTA='\033[0;35m'
+NC='\033[0m'
+
+header() { echo -e "\n${CYAN}=== $1 ===${NC}"; }
+ok()     { echo -e "${GREEN}[OK]${NC} $1"; }
+info()   { echo -e "${YELLOW}[INFO]${NC} $1"; }
+err()    { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# --- Preflight ---
+header "KEDA Autoscaling Test"
+echo "Namespace:       $NAMESPACE"
+echo "Total messages:  $TOTAL_MESSAGES"
+echo ""
+
+header "Preflight Checks"
+
+if ! kubectl get crd scaledobjects.keda.sh &>/dev/null; then
+    err "KEDA CRDs not found. Install KEDA first:"
+    echo "  helm repo add kedacore https://kedacore.github.io/charts"
+    echo "  helm install keda kedacore/keda --namespace keda --create-namespace"
+    exit 1
+fi
+ok "KEDA CRDs found"
+
+if ! kubectl get scaledobject -n "$NAMESPACE" --no-headers 2>/dev/null | grep -q .; then
+    err "No ScaledObject found in namespace '$NAMESPACE'"
+    exit 1
+fi
+ok "ScaledObject found"
+
+# --- Initial State ---
+header "Initial State"
+info "Processing Service pods:"
+kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=processing-service" --no-headers
+echo ""
+info "ScaledObject:"
+kubectl get scaledobject -n "$NAMESPACE"
+
+# --- Port Forward ---
+PORT_FORWARD_PID=""
+if [ -z "$INGRESS_URL" ]; then
+    header "Setting Up Port Forward"
+    INGEST_POD=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=ingestion-api" -o jsonpath="{.items[0].metadata.name}")
+    kubectl port-forward -n "$NAMESPACE" "$INGEST_POD" 8080:8000 &>/dev/null &
+    PORT_FORWARD_PID=$!
+    sleep 3
+    BASE_URL="http://localhost:8080"
+    ok "Port forward active: $BASE_URL -> $INGEST_POD"
+else
+    BASE_URL="${INGRESS_URL%/}"
+    ok "Using external URL: $BASE_URL"
+fi
+
+cleanup() {
+    if [ -n "$PORT_FORWARD_PID" ]; then
+        kill "$PORT_FORWARD_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# --- Verify API ---
+header "Verifying API"
+if curl -sf "$BASE_URL/health" > /dev/null; then
+    ok "Ingestion API is reachable"
+else
+    err "Cannot reach ingestion API at $BASE_URL/health"
+    exit 1
+fi
+
+# --- Flood ---
+header "Flooding Stream with $TOTAL_MESSAGES Messages"
+info "Sending readings as fast as possible to build backlog..."
+echo ""
+
+SENT=0
+ERRORS=0
+START_TIME=$(date +%s)
+
+for i in $(seq 1 "$TOTAL_MESSAGES"); do
+    SITE_NUM=$(( (i % 5) + 1 ))
+    POWER=$(awk "BEGIN{printf \"%.1f\", 100 + rand() * 4900}")
+    TS=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "$BASE_URL/readings" \
+        -H "Content-Type: application/json" \
+        -d "{\"site_id\":\"load-test-site-$SITE_NUM\",\"device_id\":\"meter-$i\",\"power_reading\":$POWER,\"timestamp\":\"$TS\"}")
+
+    if [ "$HTTP_CODE" = "201" ]; then
+        SENT=$((SENT + 1))
+    else
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    # Progress every 10 messages
+    if [ $((i % 10)) -eq 0 ]; then
+        PCT=$((i * 100 / TOTAL_MESSAGES))
+        printf "\r  Sent: %d / %d (%d%%) | Errors: %d" "$SENT" "$TOTAL_MESSAGES" "$PCT" "$ERRORS"
+    fi
+done
+
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
+echo ""
+ok "Flood complete: $SENT sent, $ERRORS errors in ${ELAPSED}s"
+
+# --- Monitor ---
+header "Monitoring KEDA Scaling (~2 minutes)"
+info "KEDA polls every 15-30s. Watch for replica count changes..."
+info "Press Ctrl+C to stop early."
+echo ""
+
+MAX_WAIT=120
+ELAPSED=0
+PREV_REPLICAS=-1
+SCALED_UP=false
+
+while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+    REPLICAS=$(kubectl get deployment -n "$NAMESPACE" \
+        -l "app.kubernetes.io/component=processing-service" \
+        -o jsonpath="{.items[0].status.replicas}" 2>/dev/null || echo "?")
+
+    READY=$(kubectl get deployment -n "$NAMESPACE" \
+        -l "app.kubernetes.io/component=processing-service" \
+        -o jsonpath="{.items[0].status.readyReplicas}" 2>/dev/null || echo "0")
+    [ -z "$READY" ] && READY="0"
+
+    HPA_DESIRED=$(kubectl get hpa -n "$NAMESPACE" \
+        -o jsonpath="{.items[0].status.desiredReplicas}" 2>/dev/null || echo "?")
+
+    NOW=$(date +"%H:%M:%S")
+
+    if [ "$REPLICAS" != "$PREV_REPLICAS" ] && [ "$PREV_REPLICAS" != "-1" ]; then
+        echo ""
+        if [ "$REPLICAS" -gt "$PREV_REPLICAS" ] 2>/dev/null; then
+            echo -e "  ${GREEN}>>> SCALED UP: $PREV_REPLICAS -> $REPLICAS replicas <<<${NC}"
+            SCALED_UP=true
+        else
+            echo -e "  ${MAGENTA}>>> SCALED DOWN: $PREV_REPLICAS -> $REPLICAS replicas <<<${NC}"
+        fi
+    fi
+    PREV_REPLICAS="$REPLICAS"
+
+    printf "\r  [%s] Replicas: %s/%s ready | HPA desired: %s | Elapsed: %ds  " \
+        "$NOW" "$READY" "$REPLICAS" "$HPA_DESIRED" "$ELAPSED"
+
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+done
+
+echo ""
+
+# --- Results ---
+header "Final State"
+info "Processing Service pods:"
+kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=processing-service"
+echo ""
+info "ScaledObject:"
+kubectl get scaledobject -n "$NAMESPACE"
+echo ""
+info "HPA (created by KEDA):"
+kubectl get hpa -n "$NAMESPACE"
+
+if [ "$SCALED_UP" = true ]; then
+    echo ""
+    ok "SUCCESS: KEDA autoscaling worked! Pods scaled up in response to stream backlog."
+else
+    echo ""
+    info "Pods didn't scale during the monitoring window."
+    info "Try: increasing messages (500+), or check: kubectl describe scaledobject -n $NAMESPACE"
+fi
+
+echo ""
+info "To clean up test data:"
+echo "  kubectl exec -n $NAMESPACE deploy/energy-pipeline-redis-master -- redis-cli DEL site:load-test-site-1:readings site:load-test-site-2:readings site:load-test-site-3:readings site:load-test-site-4:readings site:load-test-site-5:readings"

--- a/scripts/test-keda-autoscaling.sh
+++ b/scripts/test-keda-autoscaling.sh
@@ -9,6 +9,9 @@
 # Examples:
 #   ./scripts/test-keda-autoscaling.sh energy-pipeline 100
 #   ./scripts/test-keda-autoscaling.sh energy-pipeline 200 https://energy.frishchin.com
+#
+# When INGRESS_URL is provided, requests go through the frontend proxy (/api/readings).
+# When omitted, port-forwards directly to the ingestion API (/readings).
 
 set -euo pipefail
 
@@ -58,8 +61,10 @@ echo ""
 info "ScaledObject:"
 kubectl get scaledobject -n "$NAMESPACE"
 
-# --- Port Forward ---
+# --- Port Forward or External URL ---
 PORT_FORWARD_PID=""
+READINGS_ENDPOINT=""
+
 if [ -z "$INGRESS_URL" ]; then
     header "Setting Up Port Forward"
     INGEST_POD=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=ingestion-api" -o jsonpath="{.items[0].metadata.name}")
@@ -67,10 +72,17 @@ if [ -z "$INGRESS_URL" ]; then
     PORT_FORWARD_PID=$!
     sleep 3
     BASE_URL="http://localhost:8080"
-    ok "Port forward active: $BASE_URL -> $INGEST_POD"
+    # Direct to ingestion API: /readings
+    READINGS_ENDPOINT="$BASE_URL/readings"
+    HEALTH_ENDPOINT="$BASE_URL/health"
+    ok "Port forward active: $BASE_URL -> $INGEST_POD (direct to ingestion API)"
 else
     BASE_URL="${INGRESS_URL%/}"
-    ok "Using external URL: $BASE_URL"
+    # Through frontend nginx proxy: /api/readings -> /readings
+    READINGS_ENDPOINT="$BASE_URL/api/readings"
+    HEALTH_ENDPOINT="$BASE_URL"
+    ok "Using external URL: $BASE_URL (through frontend proxy)"
+    info "Readings endpoint: $READINGS_ENDPOINT"
 fi
 
 cleanup() {
@@ -82,16 +94,41 @@ trap cleanup EXIT
 
 # --- Verify API ---
 header "Verifying API"
-if curl -sf "$BASE_URL/health" > /dev/null; then
-    ok "Ingestion API is reachable"
+if [ -z "$INGRESS_URL" ]; then
+    if curl -sf "$HEALTH_ENDPOINT" > /dev/null; then
+        ok "Ingestion API is reachable"
+    else
+        err "Cannot reach ingestion API at $HEALTH_ENDPOINT"
+        exit 1
+    fi
 else
-    err "Cannot reach ingestion API at $BASE_URL/health"
-    exit 1
+    if curl -sf "$HEALTH_ENDPOINT" > /dev/null; then
+        ok "Frontend reachable at $BASE_URL"
+    else
+        err "Cannot reach frontend at $HEALTH_ENDPOINT"
+        exit 1
+    fi
+    # Test the readings endpoint with a probe
+    info "Testing readings endpoint with a probe..."
+    PROBE_TS=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "$READINGS_ENDPOINT" \
+        -H "Content-Type: application/json" \
+        -d "{\"site_id\":\"probe-test\",\"device_id\":\"probe-1\",\"power_reading\":1.0,\"timestamp\":\"$PROBE_TS\"}")
+    if [ "$HTTP_CODE" = "201" ]; then
+        ok "Readings endpoint working (HTTP 201)"
+    else
+        err "Readings endpoint failed (HTTP $HTTP_CODE)"
+        err "URL: $READINGS_ENDPOINT"
+        info "Make sure the Cloudflare tunnel is routing to the frontend service."
+        exit 1
+    fi
 fi
 
 # --- Flood ---
 header "Flooding Stream with $TOTAL_MESSAGES Messages"
-info "Sending readings as fast as possible to build backlog..."
+info "This will build a backlog that triggers KEDA to scale up processing pods..."
+info "Endpoint: $READINGS_ENDPOINT"
 echo ""
 
 SENT=0
@@ -104,7 +141,7 @@ for i in $(seq 1 "$TOTAL_MESSAGES"); do
     TS=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
 
     HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-        -X POST "$BASE_URL/readings" \
+        -X POST "$READINGS_ENDPOINT" \
         -H "Content-Type: application/json" \
         -d "{\"site_id\":\"load-test-site-$SITE_NUM\",\"device_id\":\"meter-$i\",\"power_reading\":$POWER,\"timestamp\":\"$TS\"}")
 
@@ -125,6 +162,11 @@ END_TIME=$(date +%s)
 ELAPSED=$((END_TIME - START_TIME))
 echo ""
 ok "Flood complete: $SENT sent, $ERRORS errors in ${ELAPSED}s"
+
+if [ "$SENT" -eq 0 ]; then
+    err "No messages were sent successfully. Cannot test scaling."
+    exit 1
+fi
 
 # --- Monitor ---
 header "Monitoring KEDA Scaling (~2 minutes)"
@@ -147,17 +189,19 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
         -o jsonpath="{.items[0].status.readyReplicas}" 2>/dev/null || echo "0")
     [ -z "$READY" ] && READY="0"
 
+    # HPA may not exist yet — handle gracefully
     HPA_DESIRED=$(kubectl get hpa -n "$NAMESPACE" \
-        -o jsonpath="{.items[0].status.desiredReplicas}" 2>/dev/null || echo "?")
+        -o jsonpath="{.items[0].status.desiredReplicas}" 2>/dev/null || echo "n/a")
+    [ -z "$HPA_DESIRED" ] && HPA_DESIRED="n/a"
 
     NOW=$(date +"%H:%M:%S")
 
-    if [ "$REPLICAS" != "$PREV_REPLICAS" ] && [ "$PREV_REPLICAS" != "-1" ]; then
+    if [ "$REPLICAS" != "?" ] && [ "$REPLICAS" != "$PREV_REPLICAS" ] && [ "$PREV_REPLICAS" != "-1" ]; then
         echo ""
         if [ "$REPLICAS" -gt "$PREV_REPLICAS" ] 2>/dev/null; then
             echo -e "  ${GREEN}>>> SCALED UP: $PREV_REPLICAS -> $REPLICAS replicas <<<${NC}"
             SCALED_UP=true
-        else
+        elif [ "$REPLICAS" -lt "$PREV_REPLICAS" ] 2>/dev/null; then
             echo -e "  ${MAGENTA}>>> SCALED DOWN: $PREV_REPLICAS -> $REPLICAS replicas <<<${NC}"
         fi
     fi
@@ -181,7 +225,7 @@ info "ScaledObject:"
 kubectl get scaledobject -n "$NAMESPACE"
 echo ""
 info "HPA (created by KEDA):"
-kubectl get hpa -n "$NAMESPACE"
+kubectl get hpa -n "$NAMESPACE" 2>/dev/null || echo "  No HPA found (KEDA may not have created one yet)"
 
 if [ "$SCALED_UP" = true ]; then
     echo ""
@@ -189,7 +233,9 @@ if [ "$SCALED_UP" = true ]; then
 else
     echo ""
     info "Pods didn't scale during the monitoring window."
-    info "Try: increasing messages (500+), or check: kubectl describe scaledobject -n $NAMESPACE"
+    info "Try: increasing messages (500+), or check:"
+    echo "  kubectl describe scaledobject -n $NAMESPACE"
+    echo "  kubectl logs -n keda -l app=keda-operator --tail=50"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Added `scripts/test-keda-autoscaling.ps1` (PowerShell) and `scripts/test-keda-autoscaling.sh` (Bash) to validate KEDA event-driven autoscaling
- Scripts perform end-to-end testing of the scaling pipeline: flood ingestion API → backlog builds in Redis Stream → KEDA detects pending entries → processing pods scale up

## How It Works

The test exercises the KEDA ScaledObject configuration:
- **Trigger**: `redis-streams` with `pendingEntriesCount`
- **Threshold**: 5 pending entries (from `values.yaml`)
- **Scale range**: 1–3 replicas

### Test Flow
1. **Preflight**: Verifies KEDA CRDs and ScaledObject exist
2. **Port forward**: Sets up access to ingestion API (or uses external URL)
3. **Flood**: Sends 100 readings (configurable) concurrently to build a backlog
4. **Monitor**: Watches replica count for ~2 minutes, detecting scale-up/down events
5. **Report**: Shows final state and cleanup instructions

### Usage (PowerShell)
```powershell
.\scripts\test-keda-autoscaling.ps1
.\scripts\test-keda-autoscaling.ps1 -Namespace energy-pipeline -TotalMessages 200
.\scripts\test-keda-autoscaling.ps1 -IngressUrl "https://energy.frishchin.com"
```

### Usage (Bash)
```bash
./scripts/test-keda-autoscaling.sh energy-pipeline 100
./scripts/test-keda-autoscaling.sh energy-pipeline 200 https://energy.frishchin.com
```

## Test plan
- [ ] Run PowerShell script against GKE cluster with KEDA installed
- [ ] Verify processing pods scale from 1 → 2+ replicas
- [ ] Verify pods scale back down after backlog is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)